### PR TITLE
Add option: `noSandbox`

### DIFF
--- a/packages/core/src/main/__tests__/browser-puppeteer-impl.spec.ts
+++ b/packages/core/src/main/__tests__/browser-puppeteer-impl.spec.ts
@@ -36,4 +36,23 @@ describe('BrowserBlinkImpl', () => {
     );
     expect(newPage).toBeCalled();
   });
+
+  it('disables sandbox when `noSandbox` provided', async () => {
+    const settings = {
+      noSandbox: true,
+    };
+
+    await chromium.setup(settings);
+
+    expect(puppeteer.launch).toBeCalledWith(
+      expect.objectContaining({
+        args: [
+          '--disable-web-security',
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+        ],
+      }),
+    );
+    expect(newPage).toBeCalled();
+  });
 });

--- a/packages/core/src/main/browser-puppeteer-impl.ts
+++ b/packages/core/src/main/browser-puppeteer-impl.ts
@@ -15,6 +15,10 @@ export class BrowserPuppeteerImpl implements Browser {
       headless: settings.headless ?? true,
     };
 
+    if (settings.noSandbox) {
+      options.args?.push('--no-sandbox', '--disable-setuid-sandbox');
+    }
+
     if (settings.language) {
       options.args?.push(`--lang=${settings.language}`);
     }

--- a/packages/core/src/shared/config.ts
+++ b/packages/core/src/shared/config.ts
@@ -11,6 +11,7 @@ export interface Settings {
   width?: number;
   height?: number;
   headless?: boolean;
+  noSandbox?: boolean;
 }
 
 export interface Config {

--- a/packages/server/src/adapters/controllers/diagnosis-controller.ts
+++ b/packages/server/src/adapters/controllers/diagnosis-controller.ts
@@ -29,6 +29,9 @@ export class DiagnosisController {
       config: {
         extends: [],
         plugins: ['@visi/plugin-standard'],
+        settings: {
+          noSandbox: true,
+        },
         rules: {},
       },
       url,


### PR DESCRIPTION
This PR adds a new option named `noSandbox` which disables puppeteer's sandbox feature. 

Additionally, this PR also has a change in server to use `noSandbox` by default which makes the setup easier, but also might be insecure for some cases.

Therefore, I'm going to provide a Docker image #39 to make it possible to bypass setup just by using docker command.