### PR TITLE
fix: fix URL for bug reporting

### DIFF
--- a/packages/@visi/web-client/src/components/content-info/__snapshots__/content-info.spec.tsx.snap
+++ b/packages/@visi/web-client/src/components/content-info/__snapshots__/content-info.spec.tsx.snap
@@ -98,7 +98,7 @@ exports[`ContentInfo matches to the snapshot 1`] = `
                 <li>
                   <a
                     class="hover:underline text-gray-600"
-                    href="https://github.com/visible/visible/issues/news"
+                    href="https://github.com/visible/visible/issues/new"
                     rel="noreferrer"
                     target="_blank"
                   >

--- a/packages/@visi/web-client/src/components/content-info/content-info.tsx
+++ b/packages/@visi/web-client/src/components/content-info/content-info.tsx
@@ -157,7 +157,7 @@ export const ContentInfo = ({ ref: _ref }: ContentInfoProps) => {
           children: t('content-info.contact.twitter', 'Twitter'),
         },
         {
-          href: 'https://github.com/visible/visible/issues/news',
+          href: 'https://github.com/visible/visible/issues/new',
           children: t('content-info.contact.github-issues', 'Report Bugs'),
         },
       ],


### PR DESCRIPTION
Fix typo.

I didn't know if I would accept the change because this repos doesn't have `COUNTRIBUTING.md` .
If you don't accept the change, you can close the PR without notice to me.